### PR TITLE
Fix DialogueMaker editor module definition

### DIFF
--- a/Plugins/DialogueMaker/Source/DialogueMakerEditor/DialogueEditorModule.cpp
+++ b/Plugins/DialogueMaker/Source/DialogueMakerEditor/DialogueEditorModule.cpp
@@ -1,4 +1,13 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
-
 #include "DialogueEditorModule.h"
+
+#include "Modules/ModuleManager.h"
+
+void FDialogueEditorModule::StartupModule()
+{
+}
+
+void FDialogueEditorModule::ShutdownModule()
+{
+}
+
+IMPLEMENT_MODULE(FDialogueEditorModule, DialogueMakerEditor);

--- a/Plugins/DialogueMaker/Source/DialogueMakerEditor/DialogueEditorModule.h
+++ b/Plugins/DialogueMaker/Source/DialogueMakerEditor/DialogueEditorModule.h
@@ -1,25 +1,12 @@
-// Fill out your copyright notice in the Description page of Project Settings.
-
 #pragma once
 
-#include "CoreMinimal.h"
-#include "UObject/Interface.h"
-#include "DialogueEditorModule.generated.h"
+#include "Modules/ModuleManager.h"
 
-// This class does not need to be modified.
-UINTERFACE(MinimalAPI)
-class UDialogueEditorModule : public UInterface
+class FDialogueEditorModule : public IModuleInterface
 {
-	GENERATED_BODY()
-};
-
-/**
- * 
- */
-class DIALOGUEMAKEREDITOR_API IDialogueEditorModule
-{
-	GENERATED_BODY()
-
-	// Add interface functions to this class. This is the class that will be inherited to implement this interface.
 public:
+        /** IModuleInterface implementation */
+        virtual void StartupModule() override;
+        virtual void ShutdownModule() override;
 };
+


### PR DESCRIPTION
## Summary
- replace the generated interface stub in DialogueEditorModule with a proper module interface definition
- implement empty StartupModule and ShutdownModule overrides and register the module

## Testing
- Not run (not available in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68de084174088326bf47b3f433dc7e83