### PR TITLE
Update quest reward item row type reference

### DIFF
--- a/Plugins/DialogueKit/Source/DialogueKit/Public/QuestBase.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/QuestBase.h
@@ -12,7 +12,7 @@ struct FQuestStep
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tag")
 	FGameplayTag ClearTag;
 
-	UPROPERTY(EditAnywhere, Category = "Reward", meta = (RowType = "/Script/DialogueMaker.ItemRow", TitleProperty = "DisplayName"))
+	UPROPERTY(EditAnywhere, Category = "Reward", meta = (RowType = "/Script/DialogueKit.ItemRow", TitleProperty = "DisplayName"))
 	TArray<FDataTableRowHandle> RewardItems;
 };
 


### PR DESCRIPTION
## Summary
- update the quest step reward item row metadata to reference `/Script/DialogueKit.ItemRow`
- confirm no remaining `/Script/DialogueMaker.ItemRow` references remain in the plugin sources

## Testing
- not run (Unreal Editor unavailable in this environment)

------
https://chatgpt.com/codex/tasks/task_e_68ef2e1e2c688326a872a3065734b590