### PR TITLE
Enable DialogueKit plugin

### DIFF
--- a/DialogueMaker.uproject
+++ b/DialogueMaker.uproject
@@ -1,25 +1,30 @@
 {
-	"FileVersion": 3,
-	"EngineAssociation": "5.4",
-	"Category": "",
-	"Description": "",
-	"Modules": [
-		{
-			"Name": "DialogueMaker",
-			"Type": "Runtime",
-			"LoadingPhase": "Default",
-			"AdditionalDependencies": [
-				"Engine",
-				"DeveloperSettings"
-			]
-		}	],
-	"Plugins": [
-		{
-			"Name": "ModelingToolsEditorMode",
-			"Enabled": true,
-			"TargetAllowList": [
-				"Editor"
-			]
-		}
-	]
+        "FileVersion": 3,
+        "EngineAssociation": "5.4",
+        "Category": "",
+        "Description": "",
+        "Modules": [
+                {
+                        "Name": "DialogueMaker",
+                        "Type": "Runtime",
+                        "LoadingPhase": "Default",
+                        "AdditionalDependencies": [
+                                "Engine",
+                                "DeveloperSettings"
+                        ]
+                }
+        ],
+        "Plugins": [
+                {
+                        "Name": "ModelingToolsEditorMode",
+                        "Enabled": true,
+                        "TargetAllowList": [
+                                "Editor"
+                        ]
+                },
+                {
+                        "Name": "DialogueKit",
+                        "Enabled": true
+                }
+        ]
 }


### PR DESCRIPTION
## Summary
- enable the DialogueKit plugin in the project configuration so it is loaded with the project

## Testing
- UnrealBuildTool -Target=DialogueMakerEditor *(fails: tool not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68ef2e28aad08326af3caaa9a5e0a11e