### PR TITLE
Align DialogueKit editor identifiers

### DIFF
--- a/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueEdEndGraphNode.cpp
+++ b/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueEdEndGraphNode.cpp
@@ -42,7 +42,7 @@ void UDialogueEdEndGraphNode::GetNodeContextMenuActions(class UToolMenu* Menu,
 		TEXT("Delete Entry"),
 		FText::FromString(TEXT("Delete Entry")),
 		FText::FromString(TEXT("Delete the node")),
-		FSlateIcon(TEXT("DialogueMakerEditorStyle"), TEXT("DialogueMakerEditor.NodeDeleteNodeIcon")),
+                FSlateIcon(TEXT("DialogueKitEditorStyle"), TEXT("DialogueKitEditor.NodeDeleteNodeIcon")),
 		FUIAction(FExecuteAction::CreateLambda(
 			[Node] (){
 				Node->GetGraph()->RemoveNode(Node);

--- a/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueEdGraphNode.cpp
+++ b/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueEdGraphNode.cpp
@@ -129,7 +129,7 @@ void UDialogueEdGraphNode::GetNodeContextMenuActions(UToolMenu* Menu, UGraphNode
 		TEXT("Pin Entry"),
 		FText::FromString(TEXT("Add Response")),
 		FText::FromString(TEXT("Create a new Response")),
-		FSlateIcon(TEXT("DialogueMakerEditorStyle"), TEXT("DialogueMakerEditor.NodeAddPinIcon")),
+                FSlateIcon(TEXT("DialogueKitEditorStyle"), TEXT("DialogueKitEditor.NodeAddIcon")),
 		FUIAction(FExecuteAction::CreateLambda(
 			[Node] (){
 				Node->GetDialogueNodeInfo()->AddDialogueChoice(FDialogueChoice(FText::FromString(TEXT("Response"))));
@@ -145,7 +145,7 @@ void UDialogueEdGraphNode::GetNodeContextMenuActions(UToolMenu* Menu, UGraphNode
 		TEXT("Delete Pin Entry"),
 		FText::FromString(TEXT("Delete Response")),
 		FText::FromString(TEXT("Delete a last Response")),
-		FSlateIcon(TEXT("DialogueMakerEditorStyle"), TEXT("DialogueMakerEditor.NodeDeletePinIcon")),
+                FSlateIcon(TEXT("DialogueKitEditorStyle"), TEXT("DialogueKitEditor.NodeDeletePinIcon")),
 		FUIAction(FExecuteAction::CreateLambda(
 			[Node] (){
 						UEdGraphPin* Pin = Node->GetPinAt(Node->Pins.Num() - 1);
@@ -167,7 +167,7 @@ void UDialogueEdGraphNode::GetNodeContextMenuActions(UToolMenu* Menu, UGraphNode
 		TEXT("Delete Entry"),
 		FText::FromString(TEXT("Delete Node")),
 		FText::FromString(TEXT("Delete the node")),
-		FSlateIcon(TEXT("DialogueMakerEditorStyle"), TEXT("DialogueMakerEditor.NodeDeleteNodeIcon")),
+                FSlateIcon(TEXT("DialogueKitEditorStyle"), TEXT("DialogueKitEditor.NodeDeleteNodeIcon")),
 		FUIAction(FExecuteAction::CreateLambda(
 			[Node] (){
 				Node->GetGraph()->RemoveNode(Node);

--- a/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueGraphEditor.cpp
+++ b/Plugins/DialogueKit/Source/DialogueKitEditor/Private/DialogueGraphEditor.cpp
@@ -22,7 +22,7 @@
 
 #define LOCTEXT_NAMESPACE "DialogueGraphEditor"
 
-DEFINE_LOG_CATEGORY_STATIC(DialogueMakerEditorSub, Log, All);
+DEFINE_LOG_CATEGORY_STATIC(DialogueKitEditorSub, Log, All);
 
 void FDialogueGraphEditor::RegisterTabSpawners(const TSharedRef<FTabManager>& InTabManager)
 {
@@ -191,7 +191,7 @@ void FDialogueGraphEditor::UpdateEditorGraphFromWorkingAsset()
         }
         else
         {
-            UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::UpdateEditorGraphFromWorkingAsset : Unknown Node Type"));
+            UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::UpdateEditorGraphFromWorkingAsset : Unknown Node Type"));
             continue;
         }
         
@@ -319,7 +319,7 @@ bool FDialogueGraphEditor::CanConvertToDataTable() const
 // Convert to DataTable 로직
 void FDialogueGraphEditor::OnConvertToDataTableButtonClicked()
 {
-    UE_LOG(DialogueMakerEditorSub, Warning, TEXT("FDialogueGraphEditor::OnConvertToDataTableButtonClicked : Enter"));
+    UE_LOG(DialogueKitEditorSub, Warning, TEXT("FDialogueGraphEditor::OnConvertToDataTableButtonClicked : Enter"));
 
     if (DataTable == nullptr)
     {
@@ -400,20 +400,20 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
 {
     // if (Node == nullptr)
     // {
-    //     UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Node is null"));
+    //     UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Node is null"));
     //     return;
     // }
     //
     // if (Node->GetDialogueNodeType() == EDialogueType::EndNode)
     // {
-    //     UE_LOG(DialogueMakerEditorSub, Verbose, TEXT("FDialogueGraphEditor::DFSDialogueGraph : DialogueType is EndNode"));
+    //     UE_LOG(DialogueKitEditorSub, Verbose, TEXT("FDialogueGraphEditor::DFSDialogueGraph : DialogueType is EndNode"));
     //     return;
     // }
     //
     // FGuid NodeGuid = Node->NodeGuid;
     // if (VisitedSet.Contains(NodeGuid))
     // {
-    //     UE_LOG(DialogueMakerEditorSub, Verbose, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Already visited - %s"), *NodeGuid.ToString());
+    //     UE_LOG(DialogueKitEditorSub, Verbose, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Already visited - %s"), *NodeGuid.ToString());
     //     return;
     // }
     //
@@ -434,7 +434,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //     {
     //         if (OutputPins[0]->LinkedTo.Num() == 0)
     //         {
-    //             UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPins[0]->PinName.ToString());
+                //             UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPins[0]->PinName.ToString());
     //             return;
     //         }
     //         
@@ -451,7 +451,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     // UDialogueEdGraphNode* DialogueNode = Cast<UDialogueEdGraphNode>(Node);
     // if (DialogueNode == nullptr)
     // {
-    //     UE_LOG(DialogueMakerEditorSub, Error, TEXT(""));
+    //     UE_LOG(DialogueKitEditorSub, Error, TEXT(""));
     //     return;
     // }
     //
@@ -472,7 +472,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //     {
     //         if (ChoicesIndex >= DialogueNodeInfo->DialogueResponses.Num())
     //         {
-    //             UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : ChoicesIndex %d, DialogueResponses %d, %s"),
+                //             UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : ChoicesIndex %d, DialogueResponses %d, %s"),
     //                 ChoicesIndex, DialogueNodeInfo->DialogueResponses.Num(), *OutputPin->PinName.ToString());
     //             return;
     //         }
@@ -491,7 +491,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //         }
     //         else
     //         {
-    //             UE_LOG(DialogueMakerEditorSub, Warning, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Responses Output pin is not linking - %s-%s"), *NodeGuid.ToString(), *OutputPin->PinName.ToString());
+                //             UE_LOG(DialogueKitEditorSub, Warning, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Responses Output pin is not linking - %s-%s"), *NodeGuid.ToString(), *OutputPin->PinName.ToString());
     //             return;
     //         }
     //     }
@@ -503,7 +503,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //     {
     //         if (OutputPin->LinkedTo.Num() == 0)
     //         {
-    //             UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPin->PinName.ToString());
+                //             UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPin->PinName.ToString());
     //             return;
     //         }
     //         
@@ -519,7 +519,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //     {
     //         if (OutputPin->LinkedTo.Num() == 0)
     //         {
-    //             UE_LOG(DialogueMakerEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPin->PinName.ToString());
+                //             UE_LOG(DialogueKitEditorSub, Error, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Linking pin is nullptr - %s"), *OutputPin->PinName.ToString());
     //             return;
     //         }
     //         
@@ -533,7 +533,7 @@ void FDialogueGraphEditor::DFSDialogueGraph(UDialogueEdGraphNodeBase* Node, TMap
     //     }
     //     else
     //     {
-    //         UE_LOG(DialogueMakerEditorSub, Warning, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Output pin is not linking - %s-%s"), *NodeGuid.ToString(), *OutputPin->PinName.ToString());
+        //         UE_LOG(DialogueKitEditorSub, Warning, TEXT("FDialogueGraphEditor::DFSDialogueGraph : Output pin is not linking - %s-%s"), *NodeGuid.ToString(), *OutputPin->PinName.ToString());
     //         return;
     //     }
     // }

--- a/Plugins/DialogueKit/Source/DialogueKitEditor/Public/DialogueGraphEditor.h
+++ b/Plugins/DialogueKit/Source/DialogueKitEditor/Public/DialogueGraphEditor.h
@@ -52,8 +52,8 @@ private:
 	UPROPERTY()
 	TObjectPtr<UEdGraph> WorkingGraph;	// 작업 중인 Graph의 Data
 	
-	const FName GraphTabID = FName("DialogueMaker_GraphEditor");  // "DialogueGraph_Tab"
-	const FName DetailsTabID = FName("DialogueMaker_Details");	// "DialogueGraph_Tab"
+	const FName GraphTabID = FName("DialogueKit_GraphEditor");  // "DialogueGraph_Tab"
+	const FName DetailsTabID = FName("DialogueKit_Details");	// "DialogueGraph_Tab"
 	
 	// Graph가 그려지는 Slate Widget
 	TSharedPtr<SGraphEditor> WorkingGraphUI;


### PR DESCRIPTION
## Summary
- rename the DialogueGraphEditor logging category and usages to DialogueKitEditorSub
- point graph node context menu icons to the DialogueKit editor style entries
- switch remaining tab identifiers to the DialogueKit_ prefix for consistency

## Testing
- not run (Unreal build unavailable in this environment)


------
https://chatgpt.com/codex/tasks/task_e_68ef3991e1f08326a8e3bf24a995693a