### PR TITLE
Add category metadata for Blueprint API

### DIFF
--- a/Plugins/DialogueKit/Source/DialogueKit/Public/ActionSequencer.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/ActionSequencer.h
@@ -18,21 +18,21 @@ class DIALOGUEKIT_API UActionSequencer : public UObject
 	GENERATED_BODY()
 
 public :
-	UFUNCTION(BlueprintCallable)
-	void Initialize(UObject* NewInWorldContextObject);
-	
-	UFUNCTION(BlueprintCallable)
-	void AddPortraitWidget(const ESpeakerID PortraitOwner, UWidget* Widget);
-	
-	UFUNCTION(BlueprintCallable)
-	void StartSequence(const TArray<FPortraitActionData>& ActionDatas, const bool bIsSkip = false);
-	
-	UFUNCTION(BlueprintCallable)
-	void StopSequence();
-	
-	UFUNCTION(BlueprintCallable)
-	bool TryGetOffScreenPosition(const UCanvasPanelSlot* CanvasPanelSlot,
-	const EPortraitSide PortraitSide, FVector2D& OutPosition);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Action Sequencer")
+        void Initialize(UObject* NewInWorldContextObject);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Action Sequencer")
+        void AddPortraitWidget(const ESpeakerID PortraitOwner, UWidget* Widget);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Action Sequencer")
+        void StartSequence(const TArray<FPortraitActionData>& ActionDatas, const bool bIsSkip = false);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Action Sequencer")
+        void StopSequence();
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Action Sequencer")
+        bool TryGetOffScreenPosition(const UCanvasPanelSlot* CanvasPanelSlot,
+        const EPortraitSide PortraitSide, FVector2D& OutPosition);
 	
 	virtual class UWorld* GetWorld() const override;
 	
@@ -46,29 +46,29 @@ private:
 	void ClearAllTimer();
 	
 private:
-	UPROPERTY()
-	TWeakObjectPtr<UObject> InWorldContextObject;
-	
-	UPROPERTY()
-	TArray<FPortraitActionData> CachedActionDatas;
-	
-	UPROPERTY()
-	TWeakObjectPtr<UPortraitItemWidget> CurrentActionTargetWidget;
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        TWeakObjectPtr<UObject> InWorldContextObject;
 
-	UPROPERTY()
-	TMap<ESpeakerID, TWeakObjectPtr<UPortraitItemWidget>> CachedWidgetMap;
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        TArray<FPortraitActionData> CachedActionDatas;
+
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        TWeakObjectPtr<UPortraitItemWidget> CurrentActionTargetWidget;
+
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        TMap<ESpeakerID, TWeakObjectPtr<UPortraitItemWidget>> CachedWidgetMap;
 
 	int32 CurrentActionIndex = INDEX_NONE;
 	float CurrentActionElapsedTime = 0.0f;
 
-	UPROPERTY()
-	FTimerHandle DelayTimerHandle;
-	
-	UPROPERTY()
-	FTimerHandle TickTimerHandle;
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        FTimerHandle DelayTimerHandle;
+
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        FTimerHandle TickTimerHandle;
 
 	const float SequenceTickInterval = 1.0f / 60.0f;
 
-	UPROPERTY()
-	FVector2D CachedOriginalRenderTranslation = FVector2D::ZeroVector;
+        UPROPERTY(Category = "Dialogue|Action Sequencer")
+        FVector2D CachedOriginalRenderTranslation = FVector2D::ZeroVector;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueEndNodeInfo.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueEndNodeInfo.h
@@ -21,14 +21,14 @@ class DIALOGUEKIT_API UDialogueEndNodeInfo : public UDialogueNodeInfoBase
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere)
-	EDialogueNodeAction Action = EDialogueNodeAction::None;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|End Node")
+        EDialogueNodeAction Action = EDialogueNodeAction::None;
 
-	UPROPERTY(EditAnywhere)
-	FString ActionDetails;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|End Node")
+        FString ActionDetails;
 
-	UPROPERTY(EditAnywhere, meta = (ToolTip = "Quest가 없고, 대화 종료시 처리할 Tag가 있는 경우 사용"))
-	FGameplayTag ClearTag;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|End Node", meta = (ToolTip = "Quest가 없고, 대화 종료시 처리할 Tag가 있는 경우 사용"))
+        FGameplayTag ClearTag;
 
 	UPROPERTY(EditAnywhere, Category = "Quest")
 	TSoftObjectPtr<UQuestBase> QuestBase;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueGraph.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueGraph.h
@@ -24,14 +24,14 @@ struct FPortraitInitData
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	ESpeakerID Speaker;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Initial Portrait")
+        ESpeakerID Speaker;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EEmoteType EmoteType;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Initial Portrait")
+        EEmoteType EmoteType;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitSide PortraitSide;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Initial Portrait")
+        EPortraitSide PortraitSide;
 };
 
 UCLASS(BlueprintType)
@@ -65,8 +65,8 @@ public:
 public:	// Properties
 	// UPROPERTY(EditAnywhere)
 	// FString SpeakerName = FString("Enter Dialogue Name Here");
-	UPROPERTY(VisibleAnywhere)
-	TObjectPtr<UDialogueRuntimeGraph> Graph;
+        UPROPERTY(VisibleAnywhere, Category = "Dialogue|Graph")
+        TObjectPtr<UDialogueRuntimeGraph> Graph;
 
 	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Filter - Default")
 	ESpeakerID SpeakerID;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueNodeInfo.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueNodeInfo.h
@@ -11,13 +11,13 @@
 USTRUCT(BlueprintType)
 struct FSpeakerEmotePair
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadOnly)
-	ESpeakerID Speaker;
+        UPROPERTY(BlueprintReadOnly, Category = "Dialogue|Portrait")
+        ESpeakerID Speaker;
 
-	UPROPERTY(BlueprintReadOnly)
-	EEmoteType EmoteType;
+        UPROPERTY(BlueprintReadOnly, Category = "Dialogue|Portrait")
+        EEmoteType EmoteType;
 
 	FSpeakerEmotePair(){ Speaker = ESpeakerID::TestNPC, EmoteType = EEmoteType::None; };
 	FSpeakerEmotePair(ESpeakerID Speaker, EEmoteType EmoteType) : Speaker(Speaker), EmoteType(EmoteType){};
@@ -29,26 +29,26 @@ class DIALOGUEKIT_API UDialogueNodeInfo : public UDialogueNodeInfoBase
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable)
-	const FText& GetTitle() const;
-	
-	UFUNCTION(BlueprintCallable)
-	const FText& GetDialogueText() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Content")
+        const FText& GetTitle() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FDialogueChoice>& GetDialogueChoices() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Content")
+        const FText& GetDialogueText() const;
 
-	UFUNCTION(BlueprintCallable)
-	void AddDialogueChoice(const FDialogueChoice& DialogueChoice);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Content")
+        const TArray<FDialogueChoice>& GetDialogueChoices() const;
 
-	UFUNCTION(BlueprintCallable)
-	void RemoveDialogueChoiceAt(int32 Index);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Content")
+        void AddDialogueChoice(const FDialogueChoice& DialogueChoice);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Content")
+        void RemoveDialogueChoiceAt(int32 Index);
 	
 	bool IsDialogueAlreadyShown() const;
 	void SetShownCondition(const bool NewCondition);
 
-	UFUNCTION(BlueprintCallable)
-	const FSpeakerEmotePair GetSpeakerEmotePair() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait")
+        const FSpeakerEmotePair GetSpeakerEmotePair() const;
 	
 	UFUNCTION(Category= "Portrait")
 	const FPortraitData GetPortraitData() const;
@@ -75,8 +75,8 @@ private:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
 	TArray<FDialogueChoice> DialogueChoices;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-	bool bIsShown;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|State", meta = (AllowPrivateAccess = "true"))
+        bool bIsShown;
 
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Quest", meta = (AllowPrivateAccess = "true"))
 	TSubclassOf<UQuestBase> QuestToGive;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialoguePortraitData.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialoguePortraitData.h
@@ -11,16 +11,16 @@
 USTRUCT(BlueprintType)
 struct FPortraitData
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitActionType ActionType = EPortraitActionType::None;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Portrait")
+        EPortraitActionType ActionType = EPortraitActionType::None;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EEmoteType EmoteType = EEmoteType::None;        // 감정 상황에 맞는 이미지 사용
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Portrait")
+        EEmoteType EmoteType = EEmoteType::None;        // 감정 상황에 맞는 이미지 사용
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitSide SidePosition = EPortraitSide::Center;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Portrait")
+        EPortraitSide SidePosition = EPortraitSide::Center;
 };
 
 USTRUCT(BlueprintType)

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSubsystem.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSubsystem.h
@@ -24,11 +24,11 @@ struct FPortraitEmoteIDPair
 {
 	GENERATED_BODY()
 
-	UPROPERTY()
-	EEmoteType EmoteType;
+        UPROPERTY(Category = "Dialogue|Portrait Cache")
+        EEmoteType EmoteType;
 
-	UPROPERTY()
-	FPrimaryAssetId PortraitAssetId;
+        UPROPERTY(Category = "Dialogue|Portrait Cache")
+        FPrimaryAssetId PortraitAssetId;
 
 	FPortraitEmoteIDPair() {EmoteType = EEmoteType::None; PortraitAssetId = FPrimaryAssetId(); };
 	FPortraitEmoteIDPair(EEmoteType EmoteType, const FPrimaryAssetId& PortraitAssetId) : EmoteType(EmoteType), PortraitAssetId(PortraitAssetId) {};
@@ -45,11 +45,11 @@ public:
 
 	void BeginDialogue(ESpeakerID SpeakerID);
 	
-	UFUNCTION(BlueprintCallable)
-	class UDialogueNodeInfo* ProgressNextDialogue(const int32 SelectedChoiceIndex = 0, const bool bIsFirstDialogue = false);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Flow")
+        class UDialogueNodeInfo* ProgressNextDialogue(const int32 SelectedChoiceIndex = 0, const bool bIsFirstDialogue = false);
 
-	UFUNCTION(BlueprintCallable)
-	const UDialogueNodeInfo* GetCurrentDialogueNodeInfo() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Flow")
+        const UDialogueNodeInfo* GetCurrentDialogueNodeInfo() const;
 	
 	UFUNCTION(BlueprintCallable, Category = "Choice")
 	bool HasChoicesInCurrentDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
@@ -63,28 +63,28 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "Shown Dialogue")
 	bool IsAlreadyShownDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
 
-	UFUNCTION(BlueprintCallable)
-	FTimerHandle& GetSkipHandler();
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Skip")
+        FTimerHandle& GetSkipHandler();
 
-	UFUNCTION(BlueprintCallable)
-	void SetSkipHandler(const FTimerHandle& Handle);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Skip")
+        void SetSkipHandler(const FTimerHandle& Handle);
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<UDialogueNodeInfo*>& GetDialogueHistory();
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|History")
+        const TArray<UDialogueNodeInfo*>& GetDialogueHistory();
 
-	UFUNCTION(BlueprintCallable)
-	void SetDialogueRecallWidget(UUserWidget* UserWidget);
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|History")
+        void SetDialogueRecallWidget(UUserWidget* UserWidget);
 
-	UFUNCTION(BlueprintCallable)
-	UUserWidget* GetDialogueRecallWidget() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|History")
+        UUserWidget* GetDialogueRecallWidget() const;
 	
 	FPlayerCondition GetPlayerEvalCondition() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FPortraitInitData> GetInitPortraitDatas() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait")
+        const TArray<FPortraitInitData> GetInitPortraitDatas() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FPortraitActionData> GetPortraitActionDatas() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait")
+        const TArray<FPortraitActionData> GetPortraitActionDatas() const;
 
 	#if !UE_BUILD_SHIPPING
 	void PlayDialogueGraph(UDialogueGraph* DialogueGraph);
@@ -118,11 +118,11 @@ private:
 
 	void PreloadPortraits();
 
-	UFUNCTION(BlueprintCallable)
-	UTexture2D* GetPortrait(const ESpeakerID NPCID, const EEmoteType EmoteType) const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait")
+        UTexture2D* GetPortrait(const ESpeakerID NPCID, const EEmoteType EmoteType) const;
 
-	UFUNCTION(BlueprintCallable)
-	const FPortraitData GetPortraitData() const;
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait")
+        const FPortraitData GetPortraitData() const;
 
 	template<typename TEnum>
 	FString GetEnumNameString(TEnum EnumValue) const
@@ -168,13 +168,13 @@ private:
 	
 	FOnCurrentDialogueNodeChange OnCurrentDialogueChanged;
 
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable, Category = "Dialogue|Delegates")
 	FOnDialogueNodeInfoChanged OnDialogueNodeInfoChanged;
 
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable, Category = "Dialogue|Delegates")
 	FOnDialogueEnd OnDialogueEnded;
 
-	UPROPERTY(BlueprintAssignable)
+	UPROPERTY(BlueprintAssignable, Category = "Dialogue|Delegates")
 	FOnStopSkip OnStopSkip;
 	
 	UPROPERTY()
@@ -189,7 +189,7 @@ private:
 	UPROPERTY()
 	TMap<ESpeakerID, FPortraitEmoteIDPair> CachedPortraitEmotePairMap;
 
-	UPROPERTY(BlueprintReadWrite, meta = (AllowPrivateAccess = true))
+	UPROPERTY(BlueprintReadWrite, Category = "Dialogue|Portrait", meta = (AllowPrivateAccess = true))
 	TMap<ESpeakerID, EPortraitSide> CachedPortraitSideMap;
 	
 	TSharedPtr<FStreamableHandle> PortraitPreLoadHandle;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/ItemRow.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/ItemRow.h
@@ -16,22 +16,22 @@ struct FItemRow : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	FName Id;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	EItemType ItemType;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	FText DisplayName;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	FText Desc;
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	int32 Value;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Item")
 	TSoftObjectPtr<UTexture2D> Icon;
 	
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitItemWidget.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitItemWidget.h
@@ -15,29 +15,29 @@ class DIALOGUEKIT_API UPortraitItemWidget : public UUserWidget
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable)
-	void SetBaseTranslation(const FVector2D& TargetPosition);
-	
-	UFUNCTION(BlueprintCallable)
-	void SetEmoteImageTranslation(const FVector2D& TargetPosition);
-	
-	UFUNCTION(BlueprintCallable)
-	void ResetTranslation();
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait Widget")
+        void SetBaseTranslation(const FVector2D& TargetPosition);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait Widget")
+        void SetEmoteImageTranslation(const FVector2D& TargetPosition);
+
+        UFUNCTION(BlueprintCallable, Category = "Dialogue|Portrait Widget")
+        void ResetTranslation();
 
 protected:
 	virtual void NativeOnInitialized() override;
 	
 protected:
-	UPROPERTY(BlueprintReadWrite, meta = (BindWidget))
-	class UImage* PortraitImage = nullptr;
+        UPROPERTY(BlueprintReadWrite, Category = "Dialogue|Portrait Widget", meta = (BindWidget))
+        class UImage* PortraitImage = nullptr;
 
-	UPROPERTY(BlueprintReadWrite, meta = (BindWidget))
-	UImage* EmoteImage = nullptr;
+        UPROPERTY(BlueprintReadWrite, Category = "Dialogue|Portrait Widget", meta = (BindWidget))
+        UImage* EmoteImage = nullptr;
 
 private:
-	UPROPERTY()
-	FVector2D BasePortraitImageTranslation = FVector2D::ZeroVector;
+        UPROPERTY(Category = "Dialogue|Portrait Widget")
+        FVector2D BasePortraitImageTranslation = FVector2D::ZeroVector;
 
-	UPROPERTY()
-	FVector2D BaseEmoteImageTranslation = FVector2D::ZeroVector;
+        UPROPERTY(Category = "Dialogue|Portrait Widget")
+        FVector2D BaseEmoteImageTranslation = FVector2D::ZeroVector;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueConditionEvalCriteria.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueConditionEvalCriteria.h
@@ -7,23 +7,23 @@
 USTRUCT()
 struct DIALOGUEKIT_API FPlayerCondition
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
-	int32 PlayerLevel = 0;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|Condition")
+        int32 PlayerLevel = 0;
 
-	UPROPERTY(EditAnywhere)
-	FGameplayTagContainer PlayerOwnedTags;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|Condition")
+        FGameplayTagContainer PlayerOwnedTags;
 };
 
 USTRUCT(BlueprintType)
 struct DIALOGUEKIT_API FDialogueConditionEvalCriteria
 {
-	GENERATED_BODY()
+        GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
-	int32 RequiredLevel = 0;	
+        UPROPERTY(EditAnywhere, Category = "Dialogue|Condition")
+        int32 RequiredLevel = 0;
 
-	UPROPERTY(EditAnywhere)
-	FGameplayTagQuery RequiredTagQuery;
+        UPROPERTY(EditAnywhere, Category = "Dialogue|Condition")
+        FGameplayTagQuery RequiredTagQuery;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueStructure.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueStructure.h
@@ -11,11 +11,11 @@ struct FDialogueChoice
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FText ResponseText;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Choice")
+        FText ResponseText;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FDialogueConditionEvalCriteria SelectableChoiceEvalCriteria;
+        UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Dialogue|Choice")
+        FDialogueConditionEvalCriteria SelectableChoiceEvalCriteria;
 
 	FDialogueChoice(){}
 	explicit FDialogueChoice(const FText& NewResponseText) : ResponseText(NewResponseText) {}


### PR DESCRIPTION
## Summary
- add explicit Blueprint categories to ActionSequencer and PortraitItemWidget functions used by DialogueKit Blueprints
- annotate DialogueKit exposed properties with categories to satisfy engine module packaging rules
- align Dialogue subsystem metadata for delegates, portrait caches, and choice data structures

## Testing
- not run (Unreal environment not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68f0af766bf48326b819a67818b30915