### PR TITLE
Add DialogueKit categories to Blueprint metadata

### DIFF
--- a/Plugins/DialogueKit/Source/DialogueKit/Public/ActionSequencer.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/ActionSequencer.h
@@ -18,21 +18,21 @@ class DIALOGUEKIT_API UActionSequencer : public UObject
 	GENERATED_BODY()
 
 public :
-	UFUNCTION(BlueprintCallable)
-	void Initialize(UObject* NewInWorldContextObject);
-	
-	UFUNCTION(BlueprintCallable)
-	void AddPortraitWidget(const ESpeakerID PortraitOwner, UWidget* Widget);
-	
-	UFUNCTION(BlueprintCallable)
-	void StartSequence(const TArray<FPortraitActionData>& ActionDatas, const bool bIsSkip = false);
-	
-	UFUNCTION(BlueprintCallable)
-	void StopSequence();
-	
-	UFUNCTION(BlueprintCallable)
-	bool TryGetOffScreenPosition(const UCanvasPanelSlot* CanvasPanelSlot,
-	const EPortraitSide PortraitSide, FVector2D& OutPosition);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|ActionSequencer|Initialization")
+    void Initialize(UObject* NewInWorldContextObject);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|ActionSequencer|Portrait")
+    void AddPortraitWidget(const ESpeakerID PortraitOwner, UWidget* Widget);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|ActionSequencer|Sequence")
+    void StartSequence(const TArray<FPortraitActionData>& ActionDatas, const bool bIsSkip = false);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|ActionSequencer|Sequence")
+    void StopSequence();
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|ActionSequencer|Layout")
+    bool TryGetOffScreenPosition(const UCanvasPanelSlot* CanvasPanelSlot,
+    const EPortraitSide PortraitSide, FVector2D& OutPosition);
 	
 	virtual class UWorld* GetWorld() const override;
 	

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueBranchNodeInfoBase.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueBranchNodeInfoBase.h
@@ -12,6 +12,6 @@ class DIALOGUEKIT_API UDialogueBranchNodeInfoBase : public UDialogueNodeInfoBase
 public:
 	bool ConditionCheck(const FPlayerCondition& PlayerEvalCondition) const;
 	
-	UPROPERTY(EditAnywhere)
-	FDialogueConditionEvalCriteria DialoguePassCondition;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueBranchNodeInfoBase|Condition")
+    FDialogueConditionEvalCriteria DialoguePassCondition;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueEndNodeInfo.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueEndNodeInfo.h
@@ -21,26 +21,26 @@ class DIALOGUEKIT_API UDialogueEndNodeInfo : public UDialogueNodeInfoBase
 	GENERATED_BODY()
 
 public:
-	UPROPERTY(EditAnywhere)
-	EDialogueNodeAction Action = EDialogueNodeAction::None;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Action")
+    EDialogueNodeAction Action = EDialogueNodeAction::None;
 
-	UPROPERTY(EditAnywhere)
-	FString ActionDetails;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Action")
+    FString ActionDetails;
 
-	UPROPERTY(EditAnywhere, meta = (ToolTip = "Quest가 없고, 대화 종료시 처리할 Tag가 있는 경우 사용"))
-	FGameplayTag ClearTag;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Action", meta = (ToolTip = "Quest가 없고, 대화 종료시 처리할 Tag가 있는 경우 사용"))
+    FGameplayTag ClearTag;
 
-	UPROPERTY(EditAnywhere, Category = "Quest")
-	TSoftObjectPtr<UQuestBase> QuestBase;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Quest")
+    TSoftObjectPtr<UQuestBase> QuestBase;
 
-	UPROPERTY(VisibleAnywhere, Category = "Quest")
-	FGameplayTag QuestRootTag;
+    UPROPERTY(VisibleAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Quest")
+    FGameplayTag QuestRootTag;
 
-	UPROPERTY(EditAnywhere, Category = "Quest", meta = (GetOptions = "GetQuestStepTagOptions"))
-	FName SelectedQuestStepTag;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Quest", meta = (GetOptions = "GetQuestStepTagOptions"))
+    FName SelectedQuestStepTag;
 
-	UPROPERTY(VisibleAnywhere, Category = "Quest")
-	FQuestStep SelectedQuestStep;
+    UPROPERTY(VisibleAnywhere, Category = "DialogueKit|DialogueEndNodeInfo|Quest")
+    FQuestStep SelectedQuestStep;
 
 #if WITH_EDITOR
 	virtual void PostEditChangeProperty(struct FPropertyChangedEvent& PropertyChangedEvent) override;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueGraph.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueGraph.h
@@ -24,14 +24,14 @@ struct FPortraitInitData
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	ESpeakerID Speaker;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitInitData|Speaker")
+    ESpeakerID Speaker;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EEmoteType EmoteType;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitInitData|Emote")
+    EEmoteType EmoteType;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitSide PortraitSide;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitInitData|Portrait")
+    EPortraitSide PortraitSide;
 };
 
 UCLASS(BlueprintType)
@@ -65,29 +65,31 @@ public:
 public:	// Properties
 	// UPROPERTY(EditAnywhere)
 	// FString SpeakerName = FString("Enter Dialogue Name Here");
-	UPROPERTY(VisibleAnywhere)
-	TObjectPtr<UDialogueRuntimeGraph> Graph;
+        UPROPERTY(VisibleAnywhere, Category = "DialogueKit|DialogueGraph|Runtime")
+        TObjectPtr<UDialogueRuntimeGraph> Graph;
 
-	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Filter - Default")
-	ESpeakerID SpeakerID;
+        UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "DialogueKit|DialogueGraph|Filter - Default")
+        ESpeakerID SpeakerID;
 
-	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Filter - Default")
-	EChapterID ChapterID;
+        UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "DialogueKit|DialogueGraph|Filter - Default")
+        EChapterID ChapterID;
 	
-	UPROPERTY(EditAnywhere, Category = "Filter - Tags", meta = (ToolTip = "해당 Tag들이 모두 있어야 노출 조건 충족"))	FGameplayTagContainer RequiredAllTags;
+	UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueGraph|Filter - Tags", meta = (ToolTip = "해당 Tag들이 모두 있어야 노출 조건 충족"))
+	FGameplayTagContainer RequiredAllTags;
 
-	UPROPERTY(EditAnywhere, Category = "Filter - Tags", meta = (ToolTip = "해당 Tag들 중 하나라도 있으면 노출 조건 충족"))
+	UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueGraph|Filter - Tags", meta = (ToolTip = "해당 Tag들 중 하나라도 있으면 노출 조건 충족"))
 	FGameplayTagContainer RequiredAnyTags;
 
-	UPROPERTY(EditAnywhere, Category = "Filter - Tags", meta = (ToolTip = "해당 Tag들이 하나라도 있으면 미노출"))	FGameplayTagContainer BlockedAnyTags;
+	UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueGraph|Filter - Tags", meta = (ToolTip = "해당 Tag들이 하나라도 있으면 미노출"))
+	FGameplayTagContainer BlockedAnyTags;
 	
-	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Filter - Order")
-	EDialogueGraphType DialogueGraphType;
-	
-	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Filter - Order")
-	int32 DialoguePriorityWeight;
+        UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "DialogueKit|DialogueGraph|Filter - Order")
+        EDialogueGraphType DialogueGraphType;
 
-	UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "Initial Portrait")
-	TArray<FPortraitInitData> InitPortraits;
+        UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "DialogueKit|DialogueGraph|Filter - Order")
+        int32 DialoguePriorityWeight;
+
+        UPROPERTY(EditAnywhere, AssetRegistrySearchable, Category = "DialogueKit|DialogueGraph|Initial Portrait")
+        TArray<FPortraitInitData> InitPortraits;
 };
 

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueNodeInfo.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueNodeInfo.h
@@ -13,11 +13,11 @@ struct FSpeakerEmotePair
 {
 	GENERATED_BODY()
 
-	UPROPERTY(BlueprintReadOnly)
-	ESpeakerID Speaker;
+    UPROPERTY(BlueprintReadOnly, Category = "DialogueKit|FSpeakerEmotePair|Speaker")
+    ESpeakerID Speaker;
 
-	UPROPERTY(BlueprintReadOnly)
-	EEmoteType EmoteType;
+    UPROPERTY(BlueprintReadOnly, Category = "DialogueKit|FSpeakerEmotePair|Emote")
+    EEmoteType EmoteType;
 
 	FSpeakerEmotePair(){ Speaker = ESpeakerID::TestNPC, EmoteType = EEmoteType::None; };
 	FSpeakerEmotePair(ESpeakerID Speaker, EEmoteType EmoteType) : Speaker(Speaker), EmoteType(EmoteType){};
@@ -29,58 +29,58 @@ class DIALOGUEKIT_API UDialogueNodeInfo : public UDialogueNodeInfoBase
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable)
-	const FText& GetTitle() const;
-	
-	UFUNCTION(BlueprintCallable)
-	const FText& GetDialogueText() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|Dialogue")
+    const FText& GetTitle() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FDialogueChoice>& GetDialogueChoices() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|Dialogue")
+    const FText& GetDialogueText() const;
 
-	UFUNCTION(BlueprintCallable)
-	void AddDialogueChoice(const FDialogueChoice& DialogueChoice);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|Choices")
+    const TArray<FDialogueChoice>& GetDialogueChoices() const;
 
-	UFUNCTION(BlueprintCallable)
-	void RemoveDialogueChoiceAt(int32 Index);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|Choices")
+    void AddDialogueChoice(const FDialogueChoice& DialogueChoice);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|Choices")
+    void RemoveDialogueChoiceAt(int32 Index);
 	
 	bool IsDialogueAlreadyShown() const;
 	void SetShownCondition(const bool NewCondition);
 
-	UFUNCTION(BlueprintCallable)
-	const FSpeakerEmotePair GetSpeakerEmotePair() const;
-	
-	UFUNCTION(Category= "Portrait")
-	const FPortraitData GetPortraitData() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueNodeInfo|SpeakerEmote")
+    const FSpeakerEmotePair GetSpeakerEmotePair() const;
 
-	UFUNCTION(Category = "Portrait")
-	const TArray<FPortraitActionData>& GetPortraitActionDatas() const;
+    UFUNCTION(Category = "DialogueKit|DialogueNodeInfo|Portrait")
+    const FPortraitData GetPortraitData() const;
+
+    UFUNCTION(Category = "DialogueKit|DialogueNodeInfo|Portrait")
+    const TArray<FPortraitActionData>& GetPortraitActionDatas() const;
 	
 private:
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
-	FText Title;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Default", meta = (AllowPrivateAccess = "true"))
+    FText Title;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
-	ESpeakerID SpeakerID;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Default", meta = (AllowPrivateAccess = "true"))
+    ESpeakerID SpeakerID;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
-	FPortraitData PortraitData;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Default", meta = (AllowPrivateAccess = "true"))
+    FPortraitData PortraitData;
 
-	UPROPERTY(EditAnywhere, Category = "Portrait Actions")
-	TArray<FPortraitActionData> PortraitActionDatas;
-	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
-	FText DialogueText;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueNodeInfo|PortraitActions")
+    TArray<FPortraitActionData> PortraitActionDatas;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Default", meta = (AllowPrivateAccess = "true"))
-	TArray<FDialogueChoice> DialogueChoices;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Default", meta = (AllowPrivateAccess = "true"))
+    FText DialogueText;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, meta = (AllowPrivateAccess = "true"))
-	bool bIsShown;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Default", meta = (AllowPrivateAccess = "true"))
+    TArray<FDialogueChoice> DialogueChoices;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Quest", meta = (AllowPrivateAccess = "true"))
-	TSubclassOf<UQuestBase> QuestToGive;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|State", meta = (AllowPrivateAccess = "true"))
+    bool bIsShown;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Quest", meta = (AllowPrivateAccess = "true"))
-	TSubclassOf<UQuestBase> QuestToClear;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Quest", meta = (AllowPrivateAccess = "true"))
+    TSubclassOf<UQuestBase> QuestToGive;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialogueNodeInfo|Quest", meta = (AllowPrivateAccess = "true"))
+    TSubclassOf<UQuestBase> QuestToClear;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialoguePortraitData.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialoguePortraitData.h
@@ -13,14 +13,14 @@ struct FPortraitData
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitActionType ActionType = EPortraitActionType::None;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitData|Action")
+    EPortraitActionType ActionType = EPortraitActionType::None;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EEmoteType EmoteType = EEmoteType::None;        // 감정 상황에 맞는 이미지 사용
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitData|Emote")
+    EEmoteType EmoteType = EEmoteType::None;        // 감정 상황에 맞는 이미지 사용
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EPortraitSide SidePosition = EPortraitSide::Center;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitData|Placement")
+    EPortraitSide SidePosition = EPortraitSide::Center;
 };
 
 USTRUCT(BlueprintType)
@@ -28,29 +28,29 @@ struct FPortraitActionData
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Portrait")
-	ESpeakerID ActionTargetSpeakerID;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Portrait")
+    ESpeakerID ActionTargetSpeakerID;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Portrait", meta = (ToolTip = "ActionType이 Move인 경우 Action 이후 변화하는 Portarit Image, \nActionType이 Emote인 경우 Portrait에 붙어서 연출되는 Emoji Type"))
-	EEmoteType PortraitActionEmoteType = EEmoteType::None;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Portrait", meta = (ToolTip = "ActionType이 Move인 경우 Action 이후 변화하는 Portarit Image, \nActionType이 Emote인 경우 Portrait에 붙어서 연출되는 Emoji Type"))
+    EEmoteType PortraitActionEmoteType = EEmoteType::None;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Action")
-	EPortraitActionType ActionType = EPortraitActionType::None;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Action")
+    EPortraitActionType ActionType = EPortraitActionType::None;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tween")
-	float Delay = 0.0f;     // Action을 시작하기 전 Delay 시간
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Tween")
+    float Delay = 0.0f;     // Action을 시작하기 전 Delay 시간
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tween")
-	float Duration = 0.0f;  // Action 시작부터 종료까지의 전체 소요 시간
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Tween")
+    float Duration = 0.0f;  // Action 시작부터 종료까지의 전체 소요 시간
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tween")
-	FVector2D FromTranslation = FVector2D::ZeroVector;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Tween")
+    FVector2D FromTranslation = FVector2D::ZeroVector;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tween")
-	EPortraitSide TargetSide = EPortraitSide::Center;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Tween")
+    EPortraitSide TargetSide = EPortraitSide::Center;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tween")
-	FVector2D TargetSideOffset = FVector2D::ZeroVector;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FPortraitActionData|Tween")
+    FVector2D TargetSideOffset = FVector2D::ZeroVector;
 };
 
 UCLASS()
@@ -72,13 +72,13 @@ public:
 	}
 
 private:
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Speaker", AssetRegistrySearchable, meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialoguePortraitData|Speaker", AssetRegistrySearchable, meta = (AllowPrivateAccess = "true"))
 	ESpeakerID SpeakerId;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Portrait", meta = (AssetBundles = "Portrait", AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialoguePortraitData|Portrait", meta = (AssetBundles = "Portrait", AllowPrivateAccess = "true"))
 	TSoftObjectPtr<UTexture2D> Portrait;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Emote", AssetRegistrySearchable, meta = (AllowPrivateAccess = "true"))
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|DialoguePortraitData|Emote", AssetRegistrySearchable, meta = (AllowPrivateAccess = "true"))
 	EEmoteType EmoteType = EEmoteType::None;
 
 	virtual FPrimaryAssetId GetPrimaryAssetId() const override;

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSettings.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSettings.h
@@ -13,24 +13,24 @@ struct FDialogueKitScanType
 	GENERATED_BODY()
 
 	// "Dialogue" / "Quest" / "DialoguePortraitData" 등
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	FName PrimaryAssetType = NAME_None;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    FName PrimaryAssetType = NAME_None;
 
 	// "/Script/DialogueKit.DialogueGraph" 등
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	FSoftClassPath AssetBaseClass;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    FSoftClassPath AssetBaseClass;
 
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	bool bHasBlueprintClasses = false;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    bool bHasBlueprintClasses = false;
 
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	bool bIsEditorOnly = false;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    bool bIsEditorOnly = false;
 
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	TArray<FDirectoryPath> Directories;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    TArray<FDirectoryPath> Directories;
 
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	FPrimaryAssetRules Rules; 
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|FDialogueKitScanType|AssetManager")
+    FPrimaryAssetRules Rules;
 };
 
 UCLASS(Config = DialogueKit, DefaultConfig, DisplayName = "DialogueKit Settings")
@@ -39,15 +39,15 @@ class DIALOGUEKIT_API UDialogueSettings : public UDeveloperSettings
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable, Category="DialogueKit|AssetManager")
-	void ApplyKitAssetToAssetManager() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSettings|AssetManager")
+    void ApplyKitAssetToAssetManager() const;
 
 public:
-	UPROPERTY(Config, EditAnywhere, Category = "UI")
-	TSoftClassPtr<UUserWidget> DialogueWidgetClass;
+    UPROPERTY(Config, EditAnywhere, Category = "DialogueKit|DialogueSettings|UI")
+    TSoftClassPtr<UUserWidget> DialogueWidgetClass;
 
 	// 플러그인 고유 카테고리
-	UPROPERTY(EditAnywhere, Config, Category="AssetManager")
-	TArray<FDialogueKitScanType> ScanTypes;
+    UPROPERTY(EditAnywhere, Config, Category = "DialogueKit|DialogueSettings|AssetManager")
+    TArray<FDialogueKitScanType> ScanTypes;
 
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSubsystem.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/DialogueSubsystem.h
@@ -45,46 +45,46 @@ public:
 
 	void BeginDialogue(ESpeakerID SpeakerID);
 	
-	UFUNCTION(BlueprintCallable)
-	class UDialogueNodeInfo* ProgressNextDialogue(const int32 SelectedChoiceIndex = 0, const bool bIsFirstDialogue = false);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Progression")
+    class UDialogueNodeInfo* ProgressNextDialogue(const int32 SelectedChoiceIndex = 0, const bool bIsFirstDialogue = false);
 
-	UFUNCTION(BlueprintCallable)
-	const UDialogueNodeInfo* GetCurrentDialogueNodeInfo() const;
-	
-	UFUNCTION(BlueprintCallable, Category = "Choice")
-	bool HasChoicesInCurrentDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
-	
-	UFUNCTION(BlueprintCallable, Category = "Choice")
-	void GetSelectableChoiceTexts(UDialogueNodeInfo* DialogueNodeInfo, TArray<FText>& OutSelectableChoiceTexts, TArray<int32>& OutSelectableChoiceOriginalIndex) const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|CurrentDialogue")
+    const UDialogueNodeInfo* GetCurrentDialogueNodeInfo() const;
 
-	UFUNCTION(BlueprintCallable, Category = "Shown Dialogue")
-	void MakeCurrentDialogueNodeToShown();
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Choice")
+    bool HasChoicesInCurrentDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
 
-	UFUNCTION(BlueprintCallable, Category = "Shown Dialogue")
-	bool IsAlreadyShownDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Choice")
+    void GetSelectableChoiceTexts(UDialogueNodeInfo* DialogueNodeInfo, TArray<FText>& OutSelectableChoiceTexts, TArray<int32>& OutSelectableChoiceOriginalIndex) const;
 
-	UFUNCTION(BlueprintCallable)
-	FTimerHandle& GetSkipHandler();
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|ShownDialogue")
+    void MakeCurrentDialogueNodeToShown();
 
-	UFUNCTION(BlueprintCallable)
-	void SetSkipHandler(const FTimerHandle& Handle);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|ShownDialogue")
+    bool IsAlreadyShownDialogue(UDialogueNodeInfo* DialogueNodeInfo) const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<UDialogueNodeInfo*>& GetDialogueHistory();
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|SkipControl")
+    FTimerHandle& GetSkipHandler();
 
-	UFUNCTION(BlueprintCallable)
-	void SetDialogueRecallWidget(UUserWidget* UserWidget);
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|SkipControl")
+    void SetSkipHandler(const FTimerHandle& Handle);
 
-	UFUNCTION(BlueprintCallable)
-	UUserWidget* GetDialogueRecallWidget() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|History")
+    const TArray<UDialogueNodeInfo*>& GetDialogueHistory();
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|UI")
+    void SetDialogueRecallWidget(UUserWidget* UserWidget);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|UI")
+    UUserWidget* GetDialogueRecallWidget() const;
 	
 	FPlayerCondition GetPlayerEvalCondition() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FPortraitInitData> GetInitPortraitDatas() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Portrait")
+    const TArray<FPortraitInitData> GetInitPortraitDatas() const;
 
-	UFUNCTION(BlueprintCallable)
-	const TArray<FPortraitActionData> GetPortraitActionDatas() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Portrait")
+    const TArray<FPortraitActionData> GetPortraitActionDatas() const;
 
 	#if !UE_BUILD_SHIPPING
 	void PlayDialogueGraph(UDialogueGraph* DialogueGraph);
@@ -118,11 +118,11 @@ private:
 
 	void PreloadPortraits();
 
-	UFUNCTION(BlueprintCallable)
-	UTexture2D* GetPortrait(const ESpeakerID NPCID, const EEmoteType EmoteType) const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Portrait")
+    UTexture2D* GetPortrait(const ESpeakerID NPCID, const EEmoteType EmoteType) const;
 
-	UFUNCTION(BlueprintCallable)
-	const FPortraitData GetPortraitData() const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|DialogueSubsystem|Portrait")
+    const FPortraitData GetPortraitData() const;
 
 	template<typename TEnum>
 	FString GetEnumNameString(TEnum EnumValue) const
@@ -168,14 +168,14 @@ private:
 	
 	FOnCurrentDialogueNodeChange OnCurrentDialogueChanged;
 
-	UPROPERTY(BlueprintAssignable)
-	FOnDialogueNodeInfoChanged OnDialogueNodeInfoChanged;
+    UPROPERTY(BlueprintAssignable, Category = "DialogueKit|DialogueSubsystem|Events")
+    FOnDialogueNodeInfoChanged OnDialogueNodeInfoChanged;
 
-	UPROPERTY(BlueprintAssignable)
-	FOnDialogueEnd OnDialogueEnded;
+    UPROPERTY(BlueprintAssignable, Category = "DialogueKit|DialogueSubsystem|Events")
+    FOnDialogueEnd OnDialogueEnded;
 
-	UPROPERTY(BlueprintAssignable)
-	FOnStopSkip OnStopSkip;
+    UPROPERTY(BlueprintAssignable, Category = "DialogueKit|DialogueSubsystem|Events")
+    FOnStopSkip OnStopSkip;
 	
 	UPROPERTY()
 	FTimerHandle OnShownDialogueSkipTimerHandle;
@@ -189,8 +189,8 @@ private:
 	UPROPERTY()
 	TMap<ESpeakerID, FPortraitEmoteIDPair> CachedPortraitEmotePairMap;
 
-	UPROPERTY(BlueprintReadWrite, meta = (AllowPrivateAccess = true))
-	TMap<ESpeakerID, EPortraitSide> CachedPortraitSideMap;
+    UPROPERTY(BlueprintReadWrite, Category = "DialogueKit|DialogueSubsystem|Portrait", meta = (AllowPrivateAccess = true))
+    TMap<ESpeakerID, EPortraitSide> CachedPortraitSideMap;
 	
 	TSharedPtr<FStreamableHandle> PortraitPreLoadHandle;
 	

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/ItemRow.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/ItemRow.h
@@ -16,22 +16,22 @@ struct FItemRow : public FTableRowBase
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FName Id;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Identity")
+    FName Id;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	EItemType ItemType;
-	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FText DisplayName;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Type")
+    EItemType ItemType;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FText Desc;
-	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	int32 Value;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Display")
+    FText DisplayName;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	TSoftObjectPtr<UTexture2D> Icon;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Display")
+    FText Desc;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Attributes")
+    int32 Value;
+
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FItemRow|Display")
+    TSoftObjectPtr<UTexture2D> Icon;
 	
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitItemWidget.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitItemWidget.h
@@ -15,24 +15,24 @@ class DIALOGUEKIT_API UPortraitItemWidget : public UUserWidget
 	GENERATED_BODY()
 
 public:
-	UFUNCTION(BlueprintCallable)
-	void SetBaseTranslation(const FVector2D& TargetPosition);
-	
-	UFUNCTION(BlueprintCallable)
-	void SetEmoteImageTranslation(const FVector2D& TargetPosition);
-	
-	UFUNCTION(BlueprintCallable)
-	void ResetTranslation();
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|PortraitItemWidget|Layout")
+    void SetBaseTranslation(const FVector2D& TargetPosition);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|PortraitItemWidget|Layout")
+    void SetEmoteImageTranslation(const FVector2D& TargetPosition);
+
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|PortraitItemWidget|Layout")
+    void ResetTranslation();
 
 protected:
 	virtual void NativeOnInitialized() override;
 	
 protected:
-	UPROPERTY(BlueprintReadWrite, meta = (BindWidget))
-	class UImage* PortraitImage = nullptr;
+    UPROPERTY(BlueprintReadWrite, Category = "DialogueKit|PortraitItemWidget|Widget", meta = (BindWidget))
+    class UImage* PortraitImage = nullptr;
 
-	UPROPERTY(BlueprintReadWrite, meta = (BindWidget))
-	UImage* EmoteImage = nullptr;
+    UPROPERTY(BlueprintReadWrite, Category = "DialogueKit|PortraitItemWidget|Widget", meta = (BindWidget))
+    UImage* EmoteImage = nullptr;
 
 private:
 	UPROPERTY()

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitSubsystem.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/PortraitSubsystem.h
@@ -16,11 +16,11 @@ class DIALOGUEKIT_API UPortraitSubsystem : public UGameInstanceSubsystem
 public:
 	static UPortraitSubsystem* Get(const UObject* WorldContextObject);
 
-	UFUNCTION(BlueprintCallable, Category = "Portrait")
-	FAnchors GetPortraitAnchors(EPortraitSide PortraitSide) const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|PortraitSubsystem|Portrait")
+    FAnchors GetPortraitAnchors(EPortraitSide PortraitSide) const;
 
-	UFUNCTION(BlueprintCallable, Category = "Portrait")
-	FVector2D GetPortraitAlignment(EPortraitSide PortraitSide) const;
+    UFUNCTION(BlueprintCallable, Category = "DialogueKit|PortraitSubsystem|Portrait")
+    FVector2D GetPortraitAlignment(EPortraitSide PortraitSide) const;
 
 private:
 	const FAnchors LeftAnchors = FAnchors(0.1f,   0.5f, 0.1f,   0.5f);

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/QuestBase.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/QuestBase.h
@@ -9,11 +9,11 @@ struct FQuestStep
 {
 	GENERATED_BODY()
 	
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Tag")
-	FGameplayTag ClearTag;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FQuestStep|Tag")
+    FGameplayTag ClearTag;
 
-	UPROPERTY(EditAnywhere, Category = "Reward", meta = (RowType = "/Script/DialogueMaker.ItemRow", TitleProperty = "DisplayName"))
-	TArray<FDataTableRowHandle> RewardItems;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|FQuestStep|Reward", meta = (RowType = "/Script/DialogueMaker.ItemRow", TitleProperty = "DisplayName"))
+    TArray<FDataTableRowHandle> RewardItems;
 };
 
 UCLASS()
@@ -33,12 +33,12 @@ public:
 #endif
 	
 private:
-	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category="Quest|ID", meta = (AllowPrivateAccess=true))
-	FName QuestID;
+    UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "DialogueKit|QuestBase|Quest|ID", meta = (AllowPrivateAccess=true))
+    FName QuestID;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Quest|Tag", meta = (AllowPrivateAccess=true))
-	FGameplayTag QuestRootTag;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|QuestBase|Quest|Tag", meta = (AllowPrivateAccess=true))
+    FGameplayTag QuestRootTag;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Quest|Progress", meta = (AllowPrivateAccess=true))
-	TArray<FQuestStep> QuestSteps;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|QuestBase|Quest|Progress", meta = (AllowPrivateAccess=true))
+    TArray<FQuestStep> QuestSteps;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueConditionEvalCriteria.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueConditionEvalCriteria.h
@@ -9,11 +9,11 @@ struct DIALOGUEKIT_API FPlayerCondition
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
-	int32 PlayerLevel = 0;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|FPlayerCondition|Player")
+    int32 PlayerLevel = 0;
 
-	UPROPERTY(EditAnywhere)
-	FGameplayTagContainer PlayerOwnedTags;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|FPlayerCondition|Tags")
+    FGameplayTagContainer PlayerOwnedTags;
 };
 
 USTRUCT(BlueprintType)
@@ -21,9 +21,9 @@ struct DIALOGUEKIT_API FDialogueConditionEvalCriteria
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere)
-	int32 RequiredLevel = 0;	
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|FDialogueConditionEvalCriteria|Level")
+    int32 RequiredLevel = 0;
 
-	UPROPERTY(EditAnywhere)
-	FGameplayTagQuery RequiredTagQuery;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|FDialogueConditionEvalCriteria|Tags")
+    FGameplayTagQuery RequiredTagQuery;
 };

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueStructure.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/Struct/DialogueStructure.h
@@ -11,11 +11,11 @@ struct FDialogueChoice
 {
 	GENERATED_BODY()
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FText ResponseText;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FDialogueChoice|Text")
+    FText ResponseText;
 
-	UPROPERTY(EditAnywhere, BlueprintReadOnly)
-	FDialogueConditionEvalCriteria SelectableChoiceEvalCriteria;
+    UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "DialogueKit|FDialogueChoice|Conditions")
+    FDialogueConditionEvalCriteria SelectableChoiceEvalCriteria;
 
 	FDialogueChoice(){}
 	explicit FDialogueChoice(const FText& NewResponseText) : ResponseText(NewResponseText) {}

--- a/Plugins/DialogueKit/Source/DialogueKit/Public/TEST.h
+++ b/Plugins/DialogueKit/Source/DialogueKit/Public/TEST.h
@@ -21,7 +21,7 @@ protected:
 	virtual void BeginPlay() override;
 
 	public:
-	UPROPERTY(EditAnywhere)
-	TSoftObjectPtr<UDialogueGraph> TestDialogueGraph;
+    UPROPERTY(EditAnywhere, Category = "DialogueKit|ATEST|Dialogue")
+    TSoftObjectPtr<UDialogueGraph> TestDialogueGraph;
 
 };

--- a/Plugins/DialogueKit/Source/DialogueKitEditor/Public/DialogueGraphEditor.h
+++ b/Plugins/DialogueKit/Source/DialogueKitEditor/Public/DialogueGraphEditor.h
@@ -46,8 +46,8 @@ private:
 	TSharedPtr<SGraphEditor> GraphEditor;
 	TSharedPtr<IDetailsView> DetailsView;
 	
-	UPROPERTY(EditAnywhere)
-	TObjectPtr<UDialogueGraph> WorkingAsset;
+        UPROPERTY(EditAnywhere, Category = "DialogueKit|DialogueGraphEditor|Asset")
+        TObjectPtr<UDialogueGraph> WorkingAsset;
 	
 	UPROPERTY()
 	TObjectPtr<UEdGraph> WorkingGraph;	// 작업 중인 Graph의 Data


### PR DESCRIPTION
## Summary
- add DialogueKit-scoped categories to Blueprint-callable APIs across the plugin
- align Blueprint-visible properties with the DialogueKit|<Type>|<Purpose> naming scheme
- update widgets and developer settings so editor-exposed data aligns with the new metadata convention

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f1d32683fc8326bced5984f3277190